### PR TITLE
feat : Add User Entity <-> ExchangePost Entity 외래키 연결

### DIFF
--- a/src/main/java/com/talearnt/enums/post/ExchangeType.java
+++ b/src/main/java/com/talearnt/enums/post/ExchangeType.java
@@ -21,6 +21,7 @@ public enum ExchangeType {
         return type;
     }
 
+    @JsonCreator
     public static ExchangeType fromFE(String value){
         for (ExchangeType exchangeType : ExchangeType.values()){
             if(exchangeType.type.equals(value)){

--- a/src/main/java/com/talearnt/post/exchange/ExchangePostCreateReqDTO.java
+++ b/src/main/java/com/talearnt/post/exchange/ExchangePostCreateReqDTO.java
@@ -2,6 +2,7 @@ package com.talearnt.post.exchange;
 
 import com.talearnt.enums.post.ExchangeType;
 import com.talearnt.util.common.RequestDTO;
+import com.talearnt.util.jwt.UserInfo;
 import lombok.*;
 
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @RequestDTO
 public class ExchangePostCreateReqDTO {
-    private String userId;
+    private long userNo;
     private List<PostTalentCategoryDTO> giveTalent;
     private List<PostTalentCategoryDTO> receiveTalent;
     private String title;

--- a/src/main/java/com/talearnt/post/exchange/ExchangePostCreateReqDTO.java
+++ b/src/main/java/com/talearnt/post/exchange/ExchangePostCreateReqDTO.java
@@ -3,6 +3,7 @@ package com.talearnt.post.exchange;
 import com.talearnt.enums.post.ExchangeType;
 import com.talearnt.util.common.RequestDTO;
 import com.talearnt.util.jwt.UserInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
@@ -14,7 +15,8 @@ import java.util.List;
 @AllArgsConstructor
 @RequestDTO
 public class ExchangePostCreateReqDTO {
-    private long userNo;
+    @Schema(hidden = true)
+    private UserInfo userInfo; // 이거 내일 실험
     private List<PostTalentCategoryDTO> giveTalent;
     private List<PostTalentCategoryDTO> receiveTalent;
     private String title;

--- a/src/main/java/com/talearnt/post/exchange/entity/ExchangePost.java
+++ b/src/main/java/com/talearnt/post/exchange/entity/ExchangePost.java
@@ -2,6 +2,7 @@ package com.talearnt.post.exchange.entity;
 
 import com.talearnt.enums.post.ExchangePostStatus;
 import com.talearnt.enums.post.ExchangeType;
+import com.talearnt.join.User;
 import com.talearnt.util.converter.post.ExchangePostStatusConverter;
 import com.talearnt.util.converter.post.ExchangeTypeConverter;
 import jakarta.persistence.*;
@@ -22,10 +23,10 @@ public class ExchangePost {
      @Id
      @GeneratedValue(strategy = GenerationType.IDENTITY)
      private long id;
-     //외래키 거는거 시작
 
-     @Column(nullable = false, length = 30)
-     private String userId;
+     @ManyToOne
+     @JoinColumn(name = "user_no") // 내일 User Entity id 를 userNo로 변경 요청
+     private User user;
 
      @ElementCollection
      private List<PostTalentCategory> giveTalent;

--- a/src/main/java/com/talearnt/post/service/ExchangePostServiceImpl.java
+++ b/src/main/java/com/talearnt/post/service/ExchangePostServiceImpl.java
@@ -29,7 +29,7 @@ public class ExchangePostServiceImpl implements PostService {
         log.info("DTO -> Entity로 변환된 값 : {}",entity);
 
         //Data 저장
-        log.info("값 저장 : ",exchangePostRepository.save(entity));
+        exchangePostRepository.save(entity);
 
 
         return null;

--- a/src/main/java/com/talearnt/util/resolver/RequestDtoArgumentResolver.java
+++ b/src/main/java/com/talearnt/util/resolver/RequestDtoArgumentResolver.java
@@ -30,9 +30,9 @@ public class RequestDtoArgumentResolver implements HandlerMethodArgumentResolver
         if (userInfo != null) {
             // DTO의 필드 중 "userId"가 있는 경우 CustomDetails의 userId 값 주입
             for (Field field : dto.getClass().getDeclaredFields()) {
-                if (field.getName().equals("userId")) {
+                if (field.getName().equals("userInfo")) {
                     field.setAccessible(true);
-                    field.set(dto, userInfo.getUserId());
+                    field.set(dto, userInfo);
                 }
             }
         }


### PR DESCRIPTION
- 외래키를 연결했는데 문제가, UserId가 아닌 id가 필요하다.
- 또한, UserInfo를 연결하니 Swagger에서 과도한 예시가 들어온다. Swagger에서 UserInfo에 대한 입력 예제 무시하는 방법을 찾던가 아니면 userNo를 Long 타입으로 바꿔 직접 주입해주는 방식으로 진행 해야 한다.

Related to : TALEARNT-110